### PR TITLE
Update config_kbl.plist

### DIFF
--- a/CLOVER/config_kbl.plist
+++ b/CLOVER/config_kbl.plist
@@ -342,7 +342,7 @@
 	<key>SystemParameters</key>
 	<dict>
 		<key>InjectKexts</key>
-		<string>Yes</string>
+		<true/>
 		<key>InjectSystemID</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
Clover is proposing using `<true/>` tag instead of `<string>yes<string/>` for SystemParameters/InjectKexts