### PR TITLE
makefile: Include ocvalidate for update script

### DIFF
--- a/makefile.sh
+++ b/makefile.sh
@@ -1218,6 +1218,10 @@ function extractOC() {
       cp "${toolItem}" "${!OUTDir_MODEL_OC}/EFI/OC/Tools/" || copyErr
     done
     cp "OpenCore/Docs/Configuration.pdf" "${!OUTDir_MODEL_OC}/Docs/OC Configuration.pdf" || copyErr
+
+    # Copy ocvalidate for update script
+    mkdir -p "${!OUTDir_MODEL_OC}/Utilities/" || exit 1
+    cp "OpenCore/Utilities/ocvalidate/ocvalidate" "${!OUTDir_MODEL_OC}/Utilities/" || copyErr
   done
   echo
 }


### PR DESCRIPTION
This PR  copy `ocvalidate` to the `Utilities` folder in the release folder so the  OC update script can validate syntax for `config.plist` and warn the user about bad merging, acting as an extra checking.





The plan is to include the update script right after the next release, so the update script can check errors with `ocvalidate` potentially saving time and frustration.